### PR TITLE
enable sorting and filtering of listed dumps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod symlink;
 
 pub use manager::Manager;
 
-#[derive(Debug, Clone, clap::ValueEnum)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Clone, clap::ValueEnum)]
 pub enum DumpType {
     Regions,
     Nations,
@@ -20,8 +20,13 @@ impl Display for DumpType {
     }
 }
 
-#[derive(Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Dump {
     pub dump_type: DumpType,
     pub date: chrono::NaiveDate,
+}
+
+pub enum DumpOrder {
+    Ascending,
+    Descending,
 }


### PR DESCRIPTION
This PR sorts listed data dumps and adds support for listing them in reverse order and for filtering them by kind and date.

The output isn't particularly pretty but it should get the job done; for instance, there are no headers or anything of that sort to separate nation and region dumps. I thought about it but would rather not preclude use cases like piping to `wc -l` or so forth. (Detecting if output is going to stdout or redirected, for instance, seems like a potential future improvement but not critical for this feature.)

Closes #3